### PR TITLE
Fix dataset paths

### DIFF
--- a/.ipynb_checkpoints/LN Metrics Calculation-checkpoint.Rmd
+++ b/.ipynb_checkpoints/LN Metrics Calculation-checkpoint.Rmd
@@ -85,7 +85,7 @@ def convert_ln_json_to_nx_graph(json_file_path):
         
     return G
 
-lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'
+lngraph_path = 'lngraph.json'
 nxgraph = convert_ln_json_to_nx_graph(lngraph_path)
 ```
 
@@ -177,7 +177,7 @@ def convert_ln_json_to_gt_graph(json_file_path, internal_properties=True, direct
                              
     return g
 
-lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'
+lngraph_path = 'lngraph.json'
 gtgraph = convert_ln_json_to_gt_graph(lngraph_path)
 ```
 

--- a/.ipynb_checkpoints/LN Metrics Calculation-checkpoint.ipynb
+++ b/.ipynb_checkpoints/LN Metrics Calculation-checkpoint.ipynb
@@ -439,7 +439,7 @@
     "        \n",
     "    return G\n",
     "\n",
-    "lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'\n",
+    "lngraph_path = 'lngraph.json'\n",
     "nxgraph = convert_ln_json_to_nx_graph(lngraph_path)"
    ]
   },
@@ -573,7 +573,7 @@
     "                             \n",
     "    return g\n",
     "\n",
-    "lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'\n",
+    "lngraph_path = 'lngraph.json'\n",
     "gtgraph = convert_ln_json_to_gt_graph(lngraph_path)"
    ]
   },

--- a/LN Metrics Calculation.Rmd
+++ b/LN Metrics Calculation.Rmd
@@ -85,7 +85,7 @@ def convert_ln_json_to_nx_graph(json_file_path):
         
     return G
 
-lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'
+lngraph_path = 'lngraph.json'
 nxgraph = convert_ln_json_to_nx_graph(lngraph_path)
 ```
 
@@ -177,7 +177,7 @@ def convert_ln_json_to_gt_graph(json_file_path, internal_properties=True, direct
                              
     return g
 
-lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'
+lngraph_path = 'lngraph.json'
 gtgraph = convert_ln_json_to_gt_graph(lngraph_path)
 ```
 

--- a/LN Metrics Calculation.ipynb
+++ b/LN Metrics Calculation.ipynb
@@ -439,7 +439,7 @@
     "        \n",
     "    return G\n",
     "\n",
-    "lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'\n",
+    "lngraph_path = 'lngraph.json'\n",
     "nxgraph = convert_ln_json_to_nx_graph(lngraph_path)"
    ]
   },
@@ -573,7 +573,7 @@
     "                             \n",
     "    return g\n",
     "\n",
-    "lngraph_path = '/Users/steliosrammos/Documents/Datasets/LNGraph/lngraph_20193011.json'\n",
+    "lngraph_path = 'lngraph.json'\n",
     "gtgraph = convert_ln_json_to_gt_graph(lngraph_path)"
    ]
   },

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # lightning-network-analysis
 A set of tools to monitor the growth and health of the Lightning Network.
+
+Place the Lightning Network graph dataset file `lngraph.json` in the project root directory.


### PR DESCRIPTION
## Summary
- use a relative path to `lngraph.json` in notebooks and Rmd files
- document location of dataset in README

## Testing
- `python -m py_compile *.py` *(fails: `[Errno 2] No such file or directory: '*.py'`)*

------
https://chatgpt.com/codex/tasks/task_e_684199f908408329beac733e0d44662c